### PR TITLE
textInput had typo (was capitalized)

### DIFF
--- a/src/question.js
+++ b/src/question.js
@@ -156,7 +156,7 @@ Question.defaultProps = {
   value            : undefined,
   input            : {
     default     : undefined,
-    type        : 'TextInput',
+    type        : 'textInput',
     limit       : undefined,
     placeholder : undefined
   },


### PR DESCRIPTION
textInput was spelled "TextInput" which conflicted with docs and threw an error.