### PR TITLE
Fixing typo in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
     'react/addons' : 'React'
   },
   output    : {
-    libraryTarget : 'var/',
+    libraryTarget : 'var',
     library       : 'Winterfell',
     filename      : 'winterfell.min.js',
     path          : __dirname + '/dist'


### PR DESCRIPTION
There was a typo in the webpack configuration. The library target was set as var/ (directory). It should be var as in variable.