### PR TITLE
Registering custom inputtypes : Checking that the passed types parameter is actually of type object did not check the actual parameter passed in…

### DIFF
--- a/src/inputTypes/index.js
+++ b/src/inputTypes/index.js
@@ -39,7 +39,7 @@ inputTypes.addInputType = (name, instance) => {
  * @param  object types InputTypes to add. string => Component
  */
 inputTypes.addInputTypes = (types) => {
-  if (typeof messages !== 'object') {
+  if (typeof types !== 'object') {
     throw new Error('Winterfell: First parameter of addInputTypes '
                     + 'must be of type object');
   }


### PR DESCRIPTION
Registering custom inputtypes : Checking that the passed types parameter is actually of type object did not check the actual parameter passed in.