### PR TITLE
remove getDOMNode() in SelectInput

### DIFF
--- a/dist/inputTypes/selectInput.js
+++ b/dist/inputTypes/selectInput.js
@@ -64,7 +64,7 @@ var SelectInput = (function (_React$Component) {
        */
       this.handleChange({
         target: {
-          value: this.refs.select.getDOMNode().value
+          value: this.refs.select.value
         }
       });
     }

--- a/src/inputTypes/selectInput.js
+++ b/src/inputTypes/selectInput.js
@@ -47,7 +47,7 @@ class SelectInput extends React.Component {
      */
     this.handleChange({
       target : {
-        value : this.refs.select.getDOMNode().value
+        value : this.refs.select.value
       }
     });
   }


### PR DESCRIPTION
getDOMNode() deprecated

* With this change, we’re deprecating .getDOMNode() and replacing it with ReactDOM.findDOMNode (see below). If your components are currently using .getDOMNode(), they will continue to work with a warning until 0.15.
* https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html