### PR TITLE
must pass defaultChecked so CheckboxInput can use

### DIFF
--- a/src/question.js
+++ b/src/question.js
@@ -127,6 +127,7 @@ class Question extends React.Component {
                value={value}
                text={this.props.input.text}
                options={this.props.input.options}
+               defaultChecked={this.props.input.defaultChecked}
                placeholder={this.props.input.placeholder}
                required={this.props.input.required}
                classes={this.props.classes}


### PR DESCRIPTION
CheckboxInput was not able to use the defaultChecked property because it was not included in the properties sent to the input.

I can rebuild the ./dist files if you like, but when I did, there were changes in all the ./dist files, so I figured I should ask before updating them all. The changes looked like they might be innocuous minification changes.
