### PR TITLE
Added fix for react warnings

### DIFF
--- a/src/inputTypes/checkboxInput.js
+++ b/src/inputTypes/checkboxInput.js
@@ -62,8 +62,8 @@ CheckboxInput.defaultProps = {
   text     : '',
   defaultChecked: false,
   classes  : {},
-  name     : undefined,
-  value    : undefined,
+  name     : '',
+  value    : '',
   onChange : () => {},
   onBlur   : () => {}
 };

--- a/src/inputTypes/checkboxOptionsInput.js
+++ b/src/inputTypes/checkboxOptionsInput.js
@@ -60,7 +60,7 @@ class CheckboxOptionsInput extends React.Component {
 
 CheckboxOptionsInput.defaultProps = {
   classes  : {},
-  name     : undefined,
+  name     : '',
   value    : [],
   options  : [],
   onChange : () => {},

--- a/src/inputTypes/emailInput.js
+++ b/src/inputTypes/emailInput.js
@@ -38,10 +38,10 @@ class EmailInput extends React.Component {
 
 EmailInput.defaultProps = {
   classes     : {},
-  name        : undefined,
-  id          : undefined,
-  value       : undefined,
-  placeholder : undefined,
+  name        : '',
+  id          : '',
+  value       : '',
+  placeholder : '',
   onChange    : () => {},
   onBlur      : () => {},
   onKeyDown   : () => {}

--- a/src/inputTypes/fileInput.js
+++ b/src/inputTypes/fileInput.js
@@ -33,9 +33,9 @@ class FileInput extends React.Component {
 
 FileInput.defaultProps = {
   classes   : {},
-  name      : undefined,
-  id        : undefined,
-  value     : undefined,
+  name      : '',
+  id        : '',
+  value     : '',
   onChange  : () => {},
   onBlur    : () => {}
 };

--- a/src/inputTypes/hiddenInput.js
+++ b/src/inputTypes/hiddenInput.js
@@ -21,8 +21,8 @@ class HiddenInput extends React.Component {
 };
 
 HiddenInput.defaultProps = {
-  name  : undefined,
-  value : undefined
+  name  : '',
+  value : ''
 };
 
 module.exports = HiddenInput;

--- a/src/inputTypes/passwordInput.js
+++ b/src/inputTypes/passwordInput.js
@@ -38,10 +38,10 @@ class PasswordInput extends React.Component {
 
 PasswordInput.defaultProps = {
   classes     : {},
-  name        : undefined,
-  id          : undefined,
-  value       : undefined,
-  placeholder : undefined,
+  name        : '',
+  id          : '',
+  value       : '',
+  placeholder : '',
   onChange    : () => {},
   onBlur      : () => {},
   onKeyDown   : () => {}

--- a/src/inputTypes/radioOptionsInput.js
+++ b/src/inputTypes/radioOptionsInput.js
@@ -46,8 +46,8 @@ class RadioOptionsInput extends React.Component {
 
 RadioOptionsInput.defaultProps = {
   classes  : {},
-  name     : undefined,
-  value    : undefined,
+  name     : '',
+  value    : '',
   options  : [],
   onChange : () => {},
   onBlur   : () => {}

--- a/src/inputTypes/selectInput.js
+++ b/src/inputTypes/selectInput.js
@@ -56,9 +56,9 @@ class SelectInput extends React.Component {
 
 SelectInput.defaultProps = {
   classes     : {},
-  name        : undefined,
-  id          : undefined,
-  value       : undefined,
+  name        : '',
+  id          : '',
+  value       : '',
   options     : [],
   onChange    : () => {},
   onBlur      : () => {}

--- a/src/inputTypes/textInput.js
+++ b/src/inputTypes/textInput.js
@@ -38,10 +38,10 @@ class TextInput extends React.Component {
 
 TextInput.defaultProps = {
   classes     : {},
-  name        : undefined,
-  id          : undefined,
-  value       : undefined,
-  placeholder : undefined,
+  name        : '',
+  id          : '',
+  value       : '',
+  placeholder : '',
   onChange    : () => {},
   onBlur      : () => {},
   onKeyDown   : () => {}

--- a/src/inputTypes/textareaInput.js
+++ b/src/inputTypes/textareaInput.js
@@ -37,10 +37,10 @@ class TextareaInput extends React.Component {
 
 TextareaInput.defaultProps = {
   classes     : {},
-  name        : undefined,
-  id          : undefined,
-  value       : undefined,
-  placeholder : undefined,
+  name        : '',
+  id          : '',
+  value       : '',
+  placeholder : '',
   onChange    : () => {},
   onBlur      : () => {}
 };


### PR DESCRIPTION
If you initially pass undefined or null as the value prop, the component starts life as an "uncontrolled" component. Once you interact with the component, we set a value and react changes it to a "controlled" component, and issues the warning.

Changed initial values to empty strings instead of undefined.