### PR TITLE
Changes React and ReactDOM to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "url": "git://github.com/andrewhathaway/winterfell.git"
   },
   "license": "MIT",
+  "peerDependencies": {
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
+  },
   "dependencies": {
     "babelify": "^6.3.0",
     "keycodez": "^1.0.0",
     "lodash": "^3.10.1",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
     "validator": "^4.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
As mentioned in issue #99, this pull request changes React and ReactDOM to peerDependencies.  The purpose of this change is to prevent multiple copies of React from being loaded and causing errors when using it with updated versions of React (such as v16).

